### PR TITLE
Avoid disappeared `_`

### DIFF
--- a/docs/src/INSTALLATION.md
+++ b/docs/src/INSTALLATION.md
@@ -13,7 +13,7 @@ export JULIA_CMDSTAN_HOME=/Users/rob/Projects/Stan/cmdstan
 launchctl setenv JULIA_CMDSTAN_HOME /Users/rob/Projects/Stan/cmdstan
 ```
 
-to ~/.bash_profile or add `ENV["JULIA_CMDSTAN_HOME"]="./cmdstan"` to `./julia/etc/startup.jl`. 
+to `~/.bash_profile` or add `ENV["JULIA_CMDSTAN_HOME"]="./cmdstan"` to `./julia/etc/startup.jl`. 
 
 I typically prefer cmdstan not to include the cmdstan version number so no update is needed when cmdstan is updated.
 


### PR DESCRIPTION
In the resulting HTML, two continuous `_` will disappear and make the fonts italic.