### PR TITLE
Missing three end backticks of the code block

### DIFF
--- a/src/types/diagnosetype.jl
+++ b/src/types/diagnosetype.jl
@@ -51,6 +51,7 @@ Diagnose(;d=Gradient())
 ```julia
 ?Diagnostics                  : Diagnostic methods
 ?Gradient                     : Currently sole diagnostic method
+```
 """
 mutable struct Diagnose <: Method
   diagnostic::Diagnostics


### PR DESCRIPTION
The [julia code](https://stanjulia.github.io/CmdStan.jl/stable/#CmdStan.Diagnose) (or [dev version](https://stanjulia.github.io/CmdStan.jl/dev/#CmdStan.Diagnose)) doesn't present properly due to the missing three end backticks of the code block.

![Selection_090](https://user-images.githubusercontent.com/13688320/54593488-a3b3c580-4a69-11e9-89fa-5093a21cfd80.png)
