### PR TITLE
Test cmdstan 2.22.1 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,13 @@ os:
   - linux
   
 env:
-  - JULIA_CMDSTAN_HOME="$HOME/cmdstan-2.21.0/"
   
+  - JULIA_CMDSTAN_HOME="$HOME/cmdstan-2.22.0/"
 before_install:
   - OLDWD=`pwd`
   - cd ~
-  - wget https://github.com/stan-dev/cmdstan/releases/download/v2.21.0/cmdstan-2.21.0.tar.gz
-  - tar -xzpf cmdstan-2.21.0.tar.gz
+  - wget https://github.com/stan-dev/cmdstan/releases/download/v2.22.0/cmdstan-2.22.0.tar.gz
+  - tar -xzpf cmdstan-2.22.0.tar.gz
   - make -C $JULIA_CMDSTAN_HOME build
   - cd $OLDWD
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,12 @@ os:
   
 env:
   
-  - JULIA_CMDSTAN_HOME="$HOME/cmdstan-2.22.0/"
+  - JULIA_CMDSTAN_HOME="$HOME/cmdstan-2.22.1/"
 before_install:
   - OLDWD=`pwd`
   - cd ~
-  - wget https://github.com/stan-dev/cmdstan/releases/download/v2.22.0/cmdstan-2.22.0.tar.gz
-  - tar -xzpf cmdstan-2.22.0.tar.gz
+  - wget https://github.com/stan-dev/cmdstan/releases/download/v2.22.1/cmdstan-2.22.1.tar.gz
+  - tar -xzpf cmdstan-2.22.1.tar.gz
   - make -C $JULIA_CMDSTAN_HOME build
   - cd $OLDWD
   


### PR DESCRIPTION
The current version of cmdstan is 2.22.1. This PR updates `.travis.yml` to test against this latest version.