### PR TITLE
Switch to absolute path

### DIFF
--- a/examples/BernoulliOptimize/bernoulli_optimize.jl
+++ b/examples/BernoulliOptimize/bernoulli_optimize.jl
@@ -30,7 +30,7 @@ cd(ProjDir) #do
     println()
     display(optim)
     println()
-    println("Test round.(mean(optim[1][\"theta\"]), digits=1) ≈ 0.3")
+    println("Test round.(mean(optim[\"theta\"]), digits=1) ≈ 0.3")
     @test round.(mean(optim["theta"]), digits=1) ≈ 0.3
   end
 

--- a/src/main/stanmodel.jl
+++ b/src/main/stanmodel.jl
@@ -41,6 +41,7 @@ mutable struct Stanmodel
   monitors::Vector{String}
   data_file::String
   command::Vector{Base.AbstractCmd}
+  object_file::String
   method::Method
   random::Random
   init_file::String
@@ -155,6 +156,7 @@ function Stanmodel(
   
   id::Int=0
   data_file::String=""
+  object_file::String=""
   init_file::String=""
   cmdarray = fill(``, nchains)
   
@@ -173,7 +175,7 @@ function Stanmodel(
   Stanmodel(name, nchains, 
     num_warmup, num_samples, thin,
     id, model, model_file, monitors,
-    data_file, cmdarray, method, random,
+    data_file, cmdarray, object_file, method, random,
     init_file, output, printsummary, pdir, tmpdir, output_format);
 end
 

--- a/src/utilities/create_cmd_line.jl
+++ b/src/utilities/create_cmd_line.jl
@@ -23,7 +23,7 @@ function cmdline(m)
   cmd = ``
   if isa(m, Stanmodel)
     # Handle the model name field for unix and windows
-    cmd = @static Sys.isunix() ? `./$(getfield(m, :name))` : `cmd /c $(getfield(m, :name)).exe`
+    cmd = @static Sys.isunix() ? `$(getfield(m, :object_file))` : `cmd /c $(getfield(m, :object_file)).exe`
 
     # Method (sample, optimize, variational and diagnose) specific portion of the model
     cmd = `$cmd $(cmdline(getfield(m, :method)))`

--- a/src/utilities/read_diagnose.jl
+++ b/src/utilities/read_diagnose.jl
@@ -27,7 +27,7 @@ function read_diagnose(model::Stanmodel)
   local sstr
   
   for i in 1:model.nchains
-    if isfile("$(model.name)_$(res_type)_$(i).csv")
+    if isfile("$(model.object_file)_$(res_type)_$(i).csv")
       
       ## A result type file for chain i is present ##
       
@@ -35,7 +35,7 @@ function read_diagnose(model::Stanmodel)
         
         # Extract cmdstan version
         
-        str = read("$(model.name)_$(res_type)_$(i).csv", String)
+        str = read("$(model.object_file)_$(res_type)_$(i).csv", String)
         sstr = split(str)
         tdict[:stan_version] = "$(parse(Int, sstr[4])).$(parse(Int, sstr[8])).$(parse(Int, sstr[12]))"
       end

--- a/src/utilities/read_optimize.jl
+++ b/src/utilities/read_optimize.jl
@@ -28,12 +28,12 @@ function read_optimize(model::Stanmodel)
   tdict = Dict()
   
   for i in 1:model.nchains
-    if isfile("$(model.name)_$(res_type)_$(i).csv")
+    if isfile("$(model.object_file)_$(res_type)_$(i).csv")
       
       # A result type file for chain i is present ##
-      instream = open("$(model.name)_$(res_type)_$(i).csv")
+      instream = open("$(model.object_file)_$(res_type)_$(i).csv")
       if i == 1
-        open("$(model.name)_$(res_type)_$(i).csv") do instream 
+        open("$(model.object_file)_$(res_type)_$(i).csv") do instream 
           str = read(instream, String)
           sstr = split(str)
           tdict[:stan_major_version] = [parse(Int, sstr[4])]
@@ -43,7 +43,7 @@ function read_optimize(model::Stanmodel)
       end
       
       # After reopening the file, skip all comment lines
-      open("$(model.name)_$(res_type)_$(i).csv") do instream
+      open("$(model.object_file)_$(res_type)_$(i).csv") do instream
         skipchars(isspace, instream, linecomment='#')
         line = Unicode.normalize(readline(instream), newline2lf=true)
         

--- a/src/utilities/read_samples.jl
+++ b/src/utilities/read_samples.jl
@@ -50,11 +50,13 @@ function read_samples(m::Stanmodel, diagnostics=false, warmup_samples=false)
   end
   
   # Read .csv files created by each chain
-  
+
+  cnames = String[]
+  a3d = Dict{String,Any}("a" => nothing)
   for i in 1:m.nchains
-    if isfile("$(m.name)_$(ftype)_$(i).csv")
+    if isfile("$(m.object_file)_$(ftype)_$(i).csv")
       
-      instream = open("$(m.name)_$(ftype)_$(i).csv")
+      instream = open("$(m.object_file)_$(ftype)_$(i).csv")
         
       # Skip initial set of commented lines, e.g. containing
       # cmdstan version info, etc.
@@ -78,8 +80,8 @@ function read_samples(m::Stanmodel, diagnostics=false, warmup_samples=false)
       # Preserve cnames and create a3d
       
       if i == 1
-        global cnames = convert.(String, idx[indvec])
-        global a3d = fill(0.0, noofsamples, length(indvec), m.nchains)
+        append!(cnames, convert.(String, idx[indvec]))
+        a3d["a"] = fill(0.0, noofsamples, length(indvec), m.nchains)
       end
       
       # Read in the samples for all chains
@@ -93,12 +95,12 @@ function read_samples(m::Stanmodel, diagnostics=false, warmup_samples=false)
         else
           flds = parse.(Float64, split(strip(line), ","))
           flds = reshape(flds[indvec], 1, length(indvec))
-          a3d[j,:,i] = flds
+          a3d["a"][j,:,i] = flds
         end
       end   # read in samples  
     end   # select next file if it exists
   end   # loop over all chains
   
-  (a3d, cnames)
+  (a3d["a"], cnames)
   
 end   # end of read_samples

--- a/src/utilities/read_summary.jl
+++ b/src/utilities/read_summary.jl
@@ -19,7 +19,7 @@ read_summary(m::Stanmodel)
 """
 function read_summary(m::Stanmodel)
 
-  fname = "$(m.tmpdir)/$(m.name)_summary.csv"
+  fname = "$(m.object_file)_summary.csv"
   !isfile(fname) && stan_summary(m)
   
   df = CSV.read(fname, DataFrame; delim=",", comment="#")

--- a/src/utilities/read_variational.jl
+++ b/src/utilities/read_variational.jl
@@ -24,8 +24,8 @@ function read_variational(m::Stanmodel)
   ftype = lowercase(string(typeof(m.method)))
   
   for i in 1:m.nchains
-    if isfile("$(m.name)_$(ftype)_$(i).csv")
-      open("$(m.name)_$(ftype)_$(i).csv") do instream
+    if isfile("$(m.object_file)_$(ftype)_$(i).csv")
+      open("$(m.object_file)_$(ftype)_$(i).csv") do instream
         skipchars(isspace, instream, linecomment='#')
         line = Unicode.normalize(readline(instream), newline2lf=true)
         idx = split(strip(line), ",")

--- a/src/utilities/stan_summary.jl
+++ b/src/utilities/stan_summary.jl
@@ -32,7 +32,7 @@ function stan_summary(model::Stanmodel, file::String;
   CmdStanDir=CMDSTAN_HOME)
   try
     pstring = joinpath("$(CmdStanDir)", "bin", "stansummary")
-    csvfile = "$(model.name)_summary.csv"
+    csvfile = "$(model.object_file)_summary.csv"
     isfile(csvfile) && rm(csvfile)
     cmd = `$(pstring) --csv_file=$(csvfile) $(file)`
     resfile = open(cmd; read=true)
@@ -77,7 +77,7 @@ function stan_summary(model::Stanmodel, filecmd::Cmd;
     CmdStanDir=CMDSTAN_HOME)
   try
     pstring = joinpath("$(CmdStanDir)", "bin", "stansummary")
-    csvfile = "$(model.name)_summary.csv"
+    csvfile = "$(model.object_file)_summary.csv"
     isfile(csvfile) && rm(csvfile)
     cmd = `$(pstring) --csv_file=$(csvfile) $(filecmd)`
     if model.printsummary


### PR DESCRIPTION
I have had a rather pernicious problem with CmdStan that I was unable to consistently replicate. I've known it has something to do with threading, but was unable to figure out how it was thread-unsafe. When I was testing stuff today, I hit upon a way to replicate it and think I figured out the problem.

`cd()` changes the path for all threads, which means that running multiple CmdStan.jl models on different threads within a process results in somewhat random behavior, it seems.

The particular behavior I have is:
~~~julia
# p1 is the number of models to fit
# old_model is an old Stanmodel
estimates = Vector(undef, p1)
Threads.@threads for i in 1:p1
    new_model= deepcopy(old_model)

    pdir = pwd()
    while ispath(pdir)
        pdir = tempname()
    end

    new_model.pdir = pdir
    new_model.tmpdir = joinpath(splitpath(pdir)...,"tmp")

    mkpath(new_model.tmpdir)

    estimates[i] = stan(new_model)

    rm(pdir; force=true, recursive=true)
end
~~~

With the current 6.0.8, this errors some of the time (p1 > 5 or so) if fitting an identical model because it is `cd()`ing around and ends up attempting to read files using a relative path that isn't accurate because another thread moved to its own directory.

This PR switches to using an absolute path. Line 99 of `stancode.jl` now grabs the absolute path of the passed `model.tmpdir` and uses it to make a good portion of the code (other than that line and the `make` section) working-directory independent. It isn't a full fix, really, but I haven't been able to make it happen with these changes. I don't think a full fix would be possible until CmdStan becomes working directory-independent.

The long and the short of it is that I added another `_file` field to Stanmodel that is tmpdir+name and now it is referenced in most of the places where the code used to use `name`.

Tests pass locally (on Linux).