### PR TITLE
Feature/use setenv cmd

### DIFF
--- a/src/main/stancode.jl
+++ b/src/main/stancode.jl
@@ -96,168 +96,174 @@ function stan(
   @assert isdir(ProjDir) "Incorrect ProjDir specified: $(ProjDir)"
   @assert isdir(model.tmpdir) "$(model.tmpdir) not created"
   
-  cd(model.tmpdir) do 
-    isfile("$(model.name)_build.log") && rm("$(model.name)_build.log")
-    isfile("$(model.name)_make.log") && rm("$(model.name)_make.log")
-    isfile("$(model.name)_run.log") && rm("$(model.name)_run.log")
+  local tmpmodelname::String
+  tmpmodelname = joinpath(model.tmpdir, model.name)
+  file_paths = [
+    joinpath(tmpmodelname * "_build.log"),
+    joinpath(tmpmodelname * "_make.log"),
+    joinpath(tmpmodelname * "_run.log")]
+
+  for path in file_paths
+    isfile(path) && rm(path)
   end
 
-  cd(CmdStanDir) do
-    local tmpmodelname::String
-    tmpmodelname = joinpath(model.tmpdir, model.name)
-    if @static Sys.iswindows() ? true : false
-      tmpmodelname = replace(tmpmodelname*".exe", "\\" => "/")
+  if @static Sys.iswindows() ? true : false
+    tmpmodelname = replace(tmpmodelname*".exe", "\\" => "/")
+  end
+  try
+    cmd = setenv(`make $(tmpmodelname)`, ENV; dir=CmdStanDir)
+    if file_make_log
+      run(pipeline(cmd,
+        stdout="$(tmpmodelname)_make.log",
+        stderr="$(tmpmodelname)_build.log"))
+    else
+      run(pipeline(cmd,
+        stderr="$(tmpmodelname)_build.log"))
     end
-    try
-      if file_make_log
-        run(pipeline(`make $(tmpmodelname)`,
-          stdout="$(tmpmodelname)_make.log",
-          stderr="$(tmpmodelname)_build.log"))
-      else
-        run(pipeline(`make $(tmpmodelname)`,
-          stderr="$(tmpmodelname)_build.log"))
+  catch
+    println("\nAn error occurred while compiling the Stan program.\n")
+    print("Please check your Stan program in variable '$(model.name)' ")
+    print("and the contents of $(tmpmodelname)_build.log.\n")
+    println("Note that Stan does not handle blanks in path names.")
+    error("Return code = -3");
+  end
+
+  if data != Nothing && (typeof(data) <: AbstractString || check_dct_type(data))
+    if typeof(data) <: AbstractString
+      data_path = isabspath(data) ? data : joinpath(model.tmpdir, data)
+      for i in 1:model.nchains
+        cp(data_path, joinpath(model.tmpdir, "$(model.name)_$(i).data.R"), force=true)
       end
-    catch
-      println("\nAn error occurred while compiling the Stan program.\n")
-      print("Please check your Stan program in variable '$(model.name)' ")
-      print("and the contents of $(tmpmodelname)_build.log.\n")
-      println("Note that Stan does not handle blanks in path names.")
-      error("Return code = -3");
-    end
-  end
-
-  cd(model.tmpdir) do  
-    if data != Nothing && (typeof(data) <: AbstractString || check_dct_type(data))
-      if typeof(data) <: AbstractString
+    else
+      if typeof(data) <: Array && length(data) == model.nchains
         for i in 1:model.nchains
-          cp(data, "$(model.name)_$(i).data.R", force=true)
-        end   
+          if length(keys(data[i])) > 0
+            update_R_file(joinpath(model.tmpdir, "$(model.name)_$(i).data.R"), data[i])
+          end
+        end
       else
-        if typeof(data) <: Array && length(data) == model.nchains
+        if typeof(data) <: Array
           for i in 1:model.nchains
-            if length(keys(data[i])) > 0
-              update_R_file("$(model.name)_$(i).data.R", data[i])
+            if length(keys(data[1])) > 0
+              update_R_file(joinpath(model.tmpdir, "$(model.name)_$(i).data.R"), data[1])
             end
           end
         else
-          if typeof(data) <: Array
-            for i in 1:model.nchains
-              if length(keys(data[1])) > 0
-                update_R_file("$(model.name)_$(i).data.R", data[1])
-              end
-            end
-          else
-            for i in 1:model.nchains
-              if length(keys(data)) > 0
-                update_R_file("$(model.name)_$(i).data.R", data)
-              end
+          for i in 1:model.nchains
+            if length(keys(data)) > 0
+              update_R_file(joinpath(model.tmpdir, "$(model.name)_$(i).data.R"), data)
             end
           end
         end
       end
     end
-    
-    if init != Nothing && (typeof(init) <: AbstractString || check_dct_type(init))
-      if typeof(init) <: AbstractString
+  end
+  
+  if init != Nothing && (typeof(init) <: AbstractString || check_dct_type(init))
+    if typeof(init) <: AbstractString
+      init_str = isabspath(init) ? init : joinpath(model.tmpdir, init)
+      for i in 1:model.nchains
+        cp(init_str, joinpath(model.tmpdir, "$(model.name)_$(i).init.R"), force=true)
+      end
+    else
+      if typeof(init) <: Array && length(init) == model.nchains
         for i in 1:model.nchains
-          cp(init, "$(model.name)_$(i).init.R", force=true)
-        end   
+          if length(keys(init[i])) > 0
+            update_R_file(joinpath(model.tmpdir, "$(model.name)_$(i).init.R"), init[i])
+          end
+        end
       else
-        if typeof(init) <: Array && length(init) == model.nchains
+        if typeof(init) <: Array
           for i in 1:model.nchains
-            if length(keys(init[i])) > 0
-              update_R_file("$(model.name)_$(i).init.R", init[i])
+            if length(keys(init[1])) > 0
+              update_R_file(joinpath(model.tmpdir, "$(model.name)_$(i).init.R"), init[1])
             end
           end
         else
-          if typeof(init) <: Array
-            for i in 1:model.nchains
-              if length(keys(init[1])) > 0
-                update_R_file("$(model.name)_$(i).init.R", init[1])
-              end
-            end
-          else
-            for i in 1:model.nchains
-              if length(keys(init)) > 0
-                update_R_file("$(model.name)_$(i).init.R", init)
-              end
+          for i in 1:model.nchains
+            if length(keys(init)) > 0
+              update_R_file(joinpath(model.tmpdir, "$(model.name)_$(i).init.R"), init)
             end
           end
         end
       end
+    end
+  end
+  
+  for i in 1:model.nchains
+    model.id = i
+    model.data_file = joinpath(model.tmpdir, "$(model.name)_$(i).data.R")
+    if init != Nothing
+        model.init_file = joinpath(model.tmpdir, "$(model.name)_$(i).init.R")
+    end
+    if isa(model.method, Sample)
+      sample_file = joinpath(model.tmpdir, model.name*"_samples_$(i).csv")
+      model.output.file = sample_file
+      isfile(sample_file) && rm(sample_file)
+      if diagnostics
+        diagnostic_file = joinpath(model.tmpdir, model.name*"_diagnostics_$(i).csv")
+        model.output.diagnostic_file = diagnostic_file
+        isfile(diagnostic_file) && rm(diagnostic_file)
+      end
+    elseif isa(model.method, Optimize)
+      optimize_file = joinpath(model.tmpdir, "$(model.name)_optimize_$(i).csv")
+      isfile(optimize_file) && rm(optimize_file)
+      model.output.file = optimize_file
+    elseif isa(model.method, Variational)
+      variational_file = joinpath(model.tmpdir, "$(model.name)_variational_$(i).csv")
+      isfile(variational_file) && rm(variational_file)
+      model.output.file = variational_file
+    elseif isa(model.method, Diagnose)
+      diagnose_file = joinpath(model.tmpdir, "$(model.name)_diagnose_$(i).csv")
+      isfile(diagnose_file) && rm(diagnose_file)
+      model.output.file = diagnose_file
+    end
+    model.command[i] = cmdline(model)
+  end
+  
+  try
+    if file_run_log
+      run(pipeline(par(setenv.(model.command, Ref(ENV); dir=model.tmpdir)), stdout="$(model.name)_run.log"))
+    else
+      run(par(setenv.(model.command, Ref(ENV); dir=model.tmpdir)))
+    end
+  catch e
+    println("\nAn error occurred while running the previously compiled Stan program.\n")
+    print("Please check the contents of file $(model.name)_run.log and the")
+    println("'command' field in the Stanmodel, e.g. stanmodel.command.\n")
+    error("Return code = -5")
+  end
+  
+  local samplefiles = String[]
+  local ftype
+  
+  if typeof(model.method) in [Sample, Variational]
+    if isa(model.method, Sample)
+      ftype = diagnostics ? "diagnostics" : "samples"
+    else
+      ftype = lowercase(string(typeof(model.method)))
     end
     
     for i in 1:model.nchains
-      model.id = i
-      model.data_file ="$(model.name)_$(i).data.R"
-      if init != Nothing
-         model.init_file = "$(model.name)_$(i).init.R"
-      end
-      if isa(model.method, Sample)
-        model.output.file = model.name*"_samples_$(i).csv"
-        isfile("$(model.name)_samples_$(i).csv") && rm("$(model.name)_samples_$(i).csv")
-        if diagnostics
-          model.output.diagnostic_file = model.name*"_diagnostics_$(i).csv"
-          isfile("$(model.name)_diagnostics_$(i).csv") && rm("$(model.name)_diagnostics_$(i).csv")
-        end
-      elseif isa(model.method, Optimize)
-        isfile("$(model.name)_optimize_$(i).csv") && rm("$(model.name)_optimize_$(i).csv")
-        model.output.file = model.name*"_optimize_$(i).csv"
-      elseif isa(model.method, Variational)
-        isfile("$(model.name)_variational_$(i).csv") && rm("$(model.name)_variational_$(i).csv")
-        model.output.file = model.name*"_variational_$(i).csv"
-      elseif isa(model.method, Diagnose)
-        isfile("$(model.name)_diagnose_$(i).csv") && rm("$(model.name)_diagnose_$(i).csv")
-        model.output.file = model.name*"_diagnose_$(i).csv"
-      end
-      model.command[i] = cmdline(model)
+      push!(samplefiles, "$(model.name)_$(ftype)_$(i).csv")
     end
     
-    try
-      if file_run_log
-        run(pipeline(par(model.command), stdout="$(model.name)_run.log"))
-      else
-        run(par(model.command))
-      end
-    catch e
-      println("\nAn error occurred while running the previously compiled Stan program.\n")
-      print("Please check the contents of file $(model.name)_run.log and the")
-      println("'command' field in the Stanmodel, e.g. stanmodel.command.\n")
-      error("Return code = -5")
+    if summary
+      stan_summary(model, par(samplefiles), CmdStanDir=CmdStanDir)
     end
     
-    local samplefiles = String[]
-    local ftype
-    # local cnames = String[]
+    (res, cnames) = read_samples(model, diagnostics)
     
-    if typeof(model.method) in [Sample, Variational]
-      if isa(model.method, Sample)
-        ftype = diagnostics ? "diagnostics" : "samples"
-      else
-        ftype = lowercase(string(typeof(model.method)))
-      end
-      
-      for i in 1:model.nchains
-        push!(samplefiles, "$(model.name)_$(ftype)_$(i).csv")
-      end
-      
-      if summary
-        stan_summary(model, par(samplefiles), CmdStanDir=CmdStanDir)
-      end
-      
-      (res, cnames) = read_samples(model, diagnostics)
-      
-    elseif isa(model.method, Optimize)
-      res, cnames = read_optimize(model)
+  elseif isa(model.method, Optimize)
+    res, cnames = read_optimize(model)
 
-    elseif isa(model.method, Diagnose)
-      res, cnames = read_diagnose(model)
+  elseif isa(model.method, Diagnose)
+    res, cnames = read_diagnose(model)
 
-    else
-      println("\nAn unknown method is specified in the call to stan().")
-      error("Return code = -10")
-    end
-  end # cd()
+  else
+    println("\nAn unknown method is specified in the call to stan().")
+    error("Return code = -10")
+  end
 
   if model.output_format != :array
     start_sample = 1

--- a/src/utilities/parallel.jl
+++ b/src/utilities/parallel.jl
@@ -24,7 +24,7 @@ or
 ```
 
 """
-function par(cmds::Array{Base.AbstractCmd,1})
+function par(cmds::Array{<:Base.AbstractCmd,1})
   if length(cmds) > 2
     return(par([cmds[1:(length(cmds)-2)];
       Base.AndCmds(cmds[length(cmds)-1], cmds[length(cmds)])]))

--- a/src/utilities/read_diagnose.jl
+++ b/src/utilities/read_diagnose.jl
@@ -27,7 +27,8 @@ function read_diagnose(model::Stanmodel)
   local sstr
   
   for i in 1:model.nchains
-    if isfile("$(model.name)_$(res_type)_$(i).csv")
+    file_path = joinpath(model.tmpdir, "$(model.name)_$(res_type)_$(i).csv")
+    if isfile(file_path)
       
       ## A result type file for chain i is present ##
       
@@ -35,7 +36,7 @@ function read_diagnose(model::Stanmodel)
         
         # Extract cmdstan version
         
-        str = read("$(model.name)_$(res_type)_$(i).csv", String)
+        str = read(file_path, String)
         sstr = split(str)
         tdict[:stan_version] = "$(parse(Int, sstr[4])).$(parse(Int, sstr[8])).$(parse(Int, sstr[12]))"
       end

--- a/src/utilities/read_optimize.jl
+++ b/src/utilities/read_optimize.jl
@@ -28,12 +28,13 @@ function read_optimize(model::Stanmodel)
   tdict = Dict()
   
   for i in 1:model.nchains
-    if isfile("$(model.name)_$(res_type)_$(i).csv")
+    file_path = joinpath(model.tmpdir, "$(model.name)_$(res_type)_$(i).csv")
+    if isfile(file_path)
       
       # A result type file for chain i is present ##
-      instream = open("$(model.name)_$(res_type)_$(i).csv")
+      instream = open(file_path)
       if i == 1
-        open("$(model.name)_$(res_type)_$(i).csv") do instream 
+        open(file_path) do instream 
           str = read(instream, String)
           sstr = split(str)
           tdict[:stan_major_version] = [parse(Int, sstr[4])]
@@ -43,7 +44,7 @@ function read_optimize(model::Stanmodel)
       end
       
       # After reopening the file, skip all comment lines
-      open("$(model.name)_$(res_type)_$(i).csv") do instream
+      open(file_path) do instream
         skipchars(isspace, instream, linecomment='#')
         line = Unicode.normalize(readline(instream), newline2lf=true)
         

--- a/src/utilities/read_samples.jl
+++ b/src/utilities/read_samples.jl
@@ -52,9 +52,10 @@ function read_samples(m::Stanmodel, diagnostics=false, warmup_samples=false)
   # Read .csv files created by each chain
   
   for i in 1:m.nchains
-    if isfile("$(m.name)_$(ftype)_$(i).csv")
+    file_path = joinpath(m.tmpdir, "$(m.name)_$(ftype)_$(i).csv")
+    if isfile(file_path)
       
-      instream = open("$(m.name)_$(ftype)_$(i).csv")
+      instream = open(file_path)
         
       # Skip initial set of commented lines, e.g. containing
       # cmdstan version info, etc.

--- a/src/utilities/read_summary.jl
+++ b/src/utilities/read_summary.jl
@@ -19,7 +19,7 @@ read_summary(m::Stanmodel)
 """
 function read_summary(m::Stanmodel)
 
-  fname = "$(m.tmpdir)/$(m.name)_summary.csv"
+  fname = joinpath(m.tmpdir, "$(m.name)_summary.csv")
   !isfile(fname) && stan_summary(m)
   
   df = CSV.read(fname, DataFrame; delim=",", comment="#")

--- a/src/utilities/read_variational.jl
+++ b/src/utilities/read_variational.jl
@@ -24,8 +24,9 @@ function read_variational(m::Stanmodel)
   ftype = lowercase(string(typeof(m.method)))
   
   for i in 1:m.nchains
-    if isfile("$(m.name)_$(ftype)_$(i).csv")
-      open("$(m.name)_$(ftype)_$(i).csv") do instream
+    file_path = joinpath(m.tmpdir, "$(m.name)_$(ftype)_$(i).csv")
+    if isfile(file_path)
+      open(file_path) do instream
         skipchars(isspace, instream, linecomment='#')
         line = Unicode.normalize(readline(instream), newline2lf=true)
         idx = split(strip(line), ",")

--- a/src/utilities/stan_summary.jl
+++ b/src/utilities/stan_summary.jl
@@ -34,7 +34,7 @@ function stan_summary(model::Stanmodel, file::String;
     pstring = joinpath("$(CmdStanDir)", "bin", "stansummary")
     csvfile = "$(model.name)_summary.csv"
     isfile(csvfile) && rm(csvfile)
-    cmd = `$(pstring) -c $(csvfile) $(file)`
+    cmd = setenv(`$(pstring) -c $(csvfile) $(file)`, ENV; dir=model.tmpdir)
     resfile = open(cmd; read=true)
     println("Setting $(model.printsummary)")
     model.printsummary && print(read(resfile, String))
@@ -79,7 +79,7 @@ function stan_summary(model::Stanmodel, filecmd::Cmd;
     pstring = joinpath("$(CmdStanDir)", "bin", "stansummary")
     csvfile = "$(model.name)_summary.csv"
     isfile(csvfile) && rm(csvfile)
-    cmd = `$(pstring) -c $(csvfile) $(filecmd)`
+    cmd = setenv(`$(pstring) -c $(csvfile) $(filecmd)`, ENV; dir=model.tmpdir)
     if model.printsummary
       resfile = open(cmd; read=true)
       print(read(resfile, String))


### PR DESCRIPTION
This PR is in reference to #114 

It switches from using
```julia
cd(dir) do  
  # stuff
  run(cmd)
end
```

to

```julia
# stuff
run(setenv(cmd, ENV; dir=dir))
```